### PR TITLE
Update action.pp

### DIFF
--- a/manifests/action.pp
+++ b/manifests/action.pp
@@ -10,7 +10,7 @@ define curator::action (
   String $config_group = $::curator::user_group,
   String $ensure       = present,
   Hash[
-    Integer,
+    String,
     Struct[{
       action      => Enum[
         'alias',


### PR DESCRIPTION
Due to 2017.1.1 PE update: Integers are no longer allowed as hash keys. See, If a subkey is an unexpected type (e.g., you tried to use an integer as a hash key or a string as an array index), an exception is returned, in https://docs.puppet.com/hiera/3.3/lookup_types.html