### PR TITLE
Update action.pp

### DIFF
--- a/manifests/action.pp
+++ b/manifests/action.pp
@@ -10,7 +10,7 @@ define curator::action (
   String $config_group = $::curator::user_group,
   String $ensure       = present,
   Hash[
-    String,
+    Integer,
     Struct[{
       action      => Enum[
         'alias',


### PR DESCRIPTION
Today I upgraded our puppet master from version 2017.1.1 to 2017.2.4. After our previous update (to version 2017.1.1) integers were not allowed as hash key anymore by Puppet. So I created a fork and a PR to fix the Type checking. Today, after another update (to version 2017.2.4), I noticed Puppet is allowing integers as hash key again. This means that my PR is not valid anymore, but since it's already merged into the master branch it should be reverse commited.