### PR TITLE
Ease puppet filetypes for Hash values to conform with puppet-lint

### DIFF
--- a/manifests/action.pp
+++ b/manifests/action.pp
@@ -26,8 +26,8 @@ define curator::action (
         'snapshot'
       ],
       description => String,
-      options     => Hash[ String, String ],
-      filters     => Array[ Hash[ String, String ] ]
+      options     => Hash[ String, Data],
+      filters     => Array[ Hash[ String, Data ] ]
     }]
   ] $entities = {},
 ) {


### PR DESCRIPTION
Dear mvisonneau,

I would like to ease the puppet value types for hash values to be able to comply with the puppet style guide and puppet-lint.

The changes should not change anything for any current users.

These two checks are tiggering for me:
http://puppet-lint.com/checks/only_variable_string/
http://puppet-lint.com/checks/quoted_booleans/

Example:
Currently booleans need to be quoted:
```
          ignore_empty_list => 'true',
```

Thank you!