### PR TITLE
Produce a nice error message on unsupported systems

### DIFF
--- a/manifests/repository/apt.pp
+++ b/manifests/repository/apt.pp
@@ -23,6 +23,8 @@ class curator::repository::apt (
     '14.04' => '',
     '16.04' => '',
     '18.04' => '',
+
+    default => fail('Unsupported major operating system version'),
   }
 
   apt::source { 'curator':

--- a/manifests/repository/apt.pp
+++ b/manifests/repository/apt.pp
@@ -14,8 +14,15 @@ class curator::repository::apt (
   }
 
   $repo_suffix = $debian_major_version ? {
-    '9'     => '9', # Debian 9 ships with OpenSSL 1.1.0
-    default => '',
+    # Debian releases
+    '8'     => '',
+    '9'     => '9',
+
+    # Ubuntu releases
+    '12.04' => '',
+    '14.04' => '',
+    '16.04' => '',
+    '18.04' => '',
   }
 
   apt::source { 'curator':


### PR DESCRIPTION
In reply to https://github.com/mvisonneau/puppet-curator/pull/17#discussion_r264840668, revert the code that removed the hard failure when running on an unsupported system and display an appropriate error message when applicable.